### PR TITLE
Restrict compatibility from Symfony 3.0 to Symfony 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Also reads basic Doctrine annotations to handle property's type, nullable status
 
 Initially inspired by [Plumbok](https://github.com/plumbok/plumbok).
 
-Compatible with Symfony3 and Symfony4
+Compatible with Symfony from 3.0 to 4.3
 
 ![Packagist](https://img.shields.io/packagist/v/mtarld/symbok-bundle.svg?style=flat-square)
 ![GitHub](https://img.shields.io/github/license/mtarld/symbok-bundle.svg?style=flat-square)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.1",
     "nikic/php-parser": "4.*",
     "phpdocumentor/reflection-docblock": "^4.3",
-    "doctrine/orm": "~2.5 || ~2.6"
+    "doctrine/orm": "~2.7"
   },
   "autoload": {
     "psr-4": {
@@ -30,10 +30,13 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "7.5.x-dev",
-    "symfony/framework-bundle": "~4.2",
-    "symfony/yaml": "~4.2",
+    "symfony/framework-bundle": "^4.3",
+    "phpunit/phpunit": "~7.5",
+    "symfony/yaml": "<4.4",
     "friendsofphp/php-cs-fixer": "~2.14"
+  },
+  "conflict": {
+    "symfony/framework-bundle": "<3.0||>=4.4"
   },
   "scripts": {
     "test": "./vendor/bin/phpunit",


### PR DESCRIPTION
Require Symfony to be between 3.0 and 4.3 (included) for 1.x

Related to #22 